### PR TITLE
nginx がssl 接続できるようになった

### DIFF
--- a/srcs/compose.yml
+++ b/srcs/compose.yml
@@ -3,31 +3,10 @@ services:
   nginx:
     build:
       context: ./nginx
-      dockerfile: .
-    image: _nginx
+      dockerfile: ./Dockerfile
+    image: inception_nginx_dayo
     container_name: nginx
     ports:
-      - "443:443"
+      - "2525:443"
     volumes:
       - ./nginx/tools/html:/usr/share/nginx/html
-  
-  db:
-    build:
-      context: ./mariadb
-      dockerfile: .
-    image: _db
-    container_name: db
-    restart: always
-    environment:
-      - MYSQL_DATABASE=${MYSQL_DATABASE}
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
-      - MYSQL_CHARSET=${MYSQL_CHARSET}
-      - MYSQL_COLLATION=${MYSQL_COLLATION}
-    ports:
-      - "3306:3306"
-    volumes:
-      - ./mysql/data:/var/lib/mysql
-      - ./mysql/conf:/etc/mysql/conf.d
-      - ./mysql/logs:/logs

--- a/srcs/nginx/Dockerfile
+++ b/srcs/nginx/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update \
         -key /etc/nginx/secret.key -out /etc/nginx/secret.crt
 
 COPY ./conf/nginx.conf /etc/nginx/nginx.conf
+COPY ./tools/html /usr/share/nginx/html
 
 # nginxを実行
 CMD ["nginx", "-g", "daemon off;"]

--- a/srcs/nginx/Dockerfile
+++ b/srcs/nginx/Dockerfile
@@ -1,18 +1,21 @@
 # ベースイメージとしてAlpineを使用
-FROM alpine:latest
+FROM alpine:3.19
 
 # nginxをインストール
-RUN apk update && apk add nginx
-RUN apk add bash
-
-# 必要に応じて設定ファイルやコンテンツをコピー
-# COPY nginx.conf /etc/nginx/nginx.conf
-# COPY content/ /usr/share/nginx/html/
-
+RUN apk update \
+    && apk add nginx \
+    && apk add openssl \
 # nginxのログファイルのシンボリックリンクをstdoutとstderrに作成
-RUN ln -sf /dev/stdout /var/log/nginx/access.log \
-    && ln -sf /dev/stderr /var/log/nginx/error.log
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log \
+# 秘密鍵の生成 create secret key
+    && openssl genrsa 2048 > /etc/nginx/secret.key \
+# 証明書の生成 create certificate
+    && openssl req -x509 -nodes -days 30 \
+        -subj "/C=JP/ST=Tokyo/L=Tokyo/O=42tokyo/OU=student/CN=kakiba.web/emailAddress=kakiba@student.42tokyo.jp"\
+        -key /etc/nginx/secret.key -out /etc/nginx/secret.crt
+
 COPY ./conf/nginx.conf /etc/nginx/nginx.conf
 
 # nginxを実行
-CMD ["nginx", "-g", "daemon off;"]  
+CMD ["nginx", "-g", "daemon off;"]

--- a/srcs/nginx/conf/nginx.conf
+++ b/srcs/nginx/conf/nginx.conf
@@ -13,10 +13,10 @@ http {
     server {
         listen              443 ssl;
         server_name         www.example.com;
-        ssl_certificate     secret.crt; // SSL証明書
-        ssl_certificate_key secret.key; // SSL証明書の秘密鍵
-        ssl_protocols       TLSv1.2 TLSv1.3; // SSLプロトコル
-        ssl_ciphers         HIGH:!aNULL:!MD5; // encrypt algorithm
+        ssl_certificate     secret.crt; # SSL証明書
+        ssl_certificate_key secret.key; # SSL証明書の秘密鍵
+        ssl_protocols       TLSv1.2 TLSv1.3; # SSLプロトコル
+        ssl_ciphers         HIGH:!aNULL:!MD5; # encrypt algorithm
 
         location / {
             root   /usr/share/nginx/html;  # Nginxのデフォルトのhtmlディレクトリへのパス。変更が必要な場合は適宜変更してください。

--- a/srcs/nginx/conf/nginx.conf
+++ b/srcs/nginx/conf/nginx.conf
@@ -7,12 +7,16 @@ events {
 http {
     include       mime.types;
     default_type  application/octet-stream;
-    ssl_protocols TLSv1.2 TLSv1.3;
     sendfile        on;
     keepalive_timeout  65;
 
     server {
-        listen 443;
+        listen              443 ssl;
+        server_name         www.example.com;
+        ssl_certificate     secret.crt; // SSL証明書
+        ssl_certificate_key secret.key; // SSL証明書の秘密鍵
+        ssl_protocols       TLSv1.2 TLSv1.3; // SSLプロトコル
+        ssl_ciphers         HIGH:!aNULL:!MD5; // encrypt algorithm
 
         location / {
             root   /usr/share/nginx/html;  # Nginxのデフォルトのhtmlディレクトリへのパス。変更が必要な場合は適宜変更してください。


### PR DESCRIPTION
make で
2525 port からnginx 443 に接続
#7 
#8 
に勉強したことは書いた

# 次やること
- wordpress を立ち上げる
- ssl で開いた443 port のlocation ディレクティブ でwordpress に接続する